### PR TITLE
Right composer package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ curl -sS https://getcomposer.org/installer | php
 Next, run the Composer command to install the latest stable version of seafile-php-sdk:
 
 ```bash
-composer.phar require sdo/seafile-php-sdk
+composer.phar require rsd/seafile-php-sdk
 # composer.phar dump-autoload -o # not required anymore
 ```
 


### PR DESCRIPTION
 [InvalidArgumentException]
 Could not find a matching version of package sdo/seafile-php-sdk. Check the package spelling, your version constraint and that the package is available in a stability which matches your minimum-stability (dev).

https://packagist.org/packages/sdo/seafile-php-sdk - 404
https://packagist.org/packages/rsd/seafile-php-sdk - correct name