### PR TITLE
Add support for Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   ],
   "require": {
     "php": ">=7.3",
-    "guzzlehttp/guzzle": "~6.0",
+    "guzzlehttp/guzzle": "~6.0|~7.0",
     "nabil1337/case-helper": "~0.1",
     "ext-json": "*",
     "sdo/bitmask": "^1.0"

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -45,9 +45,9 @@ class Client extends \GuzzleHttp\Client
      * @param array $args Request args
      * @return ResponseInterface
      */
-    public function get($uri, $args): ResponseInterface
+    public function get($uri, array $options = []): ResponseInterface
     {
-        return parent::get($uri, $args);
+        return parent::get($uri, $options);
     }
 
     /**
@@ -55,9 +55,9 @@ class Client extends \GuzzleHttp\Client
      * @param array $args Request args
      * @return ResponseInterface
      */
-    public function put($uri, $args): ResponseInterface
+    public function put($uri, array $options = []): ResponseInterface
     {
-        return parent::put($uri, $args);
+        return parent::put($uri, $options);
     }
 
     /**
@@ -65,8 +65,8 @@ class Client extends \GuzzleHttp\Client
      * @param array $args Request args
      * @return ResponseInterface
      */
-    public function delete($uri, $args): ResponseInterface
+    public function delete($uri, array $options = []): ResponseInterface
     {
-        return parent::delete($uri, $args);
+        return parent::delete($uri, $options);
     }
 }


### PR DESCRIPTION
Allow for usage of Guzzle 7. Client method signatures have been updated to match those in Guzzle 7 (this fixes #27 ).